### PR TITLE
:robot: Automatically bump package repositories

### DIFF
--- a/.github/workflows/bump_repos.yml
+++ b/.github/workflows/bump_repos.yml
@@ -1,0 +1,26 @@
+name: Bump repositories
+on:
+  schedule:
+    - cron: 0 20 * * *
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install earthly
+        uses: Luet-lab/luet-install-action@v1
+        with:
+          repository: quay.io/kairos/packages
+          packages: utils/earthly
+      - name: Bump cos 🔧
+        run: earthly +bump-repositories
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          push-to-fork: ci-forks/osbuilder
+          commit-message: ':arrow_up: Update repositories'
+          title: ':arrow_up: Update repositories'
+          body: Bump of Kairos repositories
+          signoff: true

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,22 @@
+VERSION 0.6
+
+last-commit-packages:
+    FROM quay.io/skopeo/stable
+    RUN dnf install -y jq
+    WORKDIR build
+    RUN skopeo list-tags docker://quay.io/kairos/packages | jq -rc '.Tags | map(select( (. | contains("-repository.yaml")) )) | sort_by(. | sub("v";"") | sub("-repository.yaml";"") | sub("-";"") | split(".") | map(tonumber) ) | .[-1]' > REPO_AMD64
+    RUN skopeo list-tags docker://quay.io/kairos/packages-arm64 | jq -rc '.Tags | map(select( (. | contains("-repository.yaml")) )) | sort_by(. | sub("v";"") | sub("-repository.yaml";"") | sub("-";"") | split(".") | map(tonumber) ) | .[-1]' > REPO_ARM64
+    SAVE ARTIFACT REPO_AMD64 REPO_AMD64
+    SAVE ARTIFACT REPO_ARM64 REPO_ARM64
+
+bump-repositories:
+    FROM mikefarah/yq
+    WORKDIR build
+    COPY +last-commit-packages/REPO_AMD64 REPO_AMD64
+    COPY +last-commit-packages/REPO_ARM64 REPO_ARM64
+    ARG REPO_AMD64=$(cat REPO_AMD64)
+    ARG REPO_ARM64=$(cat REPO_ARM64)
+    COPY tools-image/luet.yaml luet.yaml
+    RUN yq eval ".repositories[0] |= . * { \"reference\": \"${REPO_AMD64}\" }" -i luet.yaml
+    RUN yq eval ".repositories[1] |= . * { \"reference\": \"${REPO_ARM64}\" }" -i luet.yaml
+    SAVE ARTIFACT luet.yaml AS LOCAL tools-image/luet.yaml


### PR DESCRIPTION
This adds an Earthfile ( so we can be consistent, and start moving things there ) with the target to bump the repository file, and also adds a workflow that triggers with a cron