### PR TITLE
Ignore kpartx failure on arm image

### DIFF
--- a/tools-image/build-arm-image.sh
+++ b/tools-image/build-arm-image.sh
@@ -446,7 +446,7 @@ sync
 sleep 5
 sync
 
-kpartx -dv $DRIVE
+kpartx -dv $DRIVE || true
 
 umount $DRIVE || true
 


### PR DESCRIPTION
Seems that if the system is slow enough, kpartx will fail to remove the devmapping and will fail the script