### PR TITLE
:sparkles: Add default config URL

### DIFF
--- a/tools-image/defaults.yaml
+++ b/tools-image/defaults.yaml
@@ -1,4 +1,5 @@
 #cloud-config
+config_url: "http://169.254.169.254/cloud-config.yaml"
 name: "Default user"
 stages:
    initramfs:


### PR DESCRIPTION
Not sure what you think about this but when working with the RPi, I'd prefer a different flow to add the configuration. IMO it would be nice if by default it calls a metadata url to fetch a config, just like VMs do on cloud providers like AWS. What do you think? I'm guessing the config can be written in such way that if commands can check the machine-id or MAC address and depending on that do specific configurations, like static IP. 

Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html