### PR TITLE
Add zstd to the osbuilder image

### DIFF
--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -71,7 +71,7 @@ COPY --from=grub-artifacts / /arm/grub/artifacts
 RUN zypper ref && zypper dup -y
 
 ## ISO Build depedencies
-RUN zypper ref && zypper in -y xfsprogs parted util-linux-systemd e2fsprogs curl util-linux udev rsync grub2 dosfstools grub2-x86_64-efi squashfs mtools xorriso lvm2
+RUN zypper ref && zypper in -y xfsprogs parted util-linux-systemd e2fsprogs curl util-linux udev rsync grub2 dosfstools grub2-x86_64-efi squashfs mtools xorriso lvm2 zstd
 RUN mkdir /config
 
 # Arm image build deps


### PR DESCRIPTION
Useful to support zstd compression when working with arm images

The idea would be to expand the options when building arm images and have different choices to provide the compressed arm images. zx (currently), qcow2 (fast and usable on qemu), zstd (very fast), etc...