### PR TITLE
Use GPT for raw images

### DIFF
--- a/tools-image/build-arm-image.sh
+++ b/tools-image/build-arm-image.sh
@@ -345,6 +345,8 @@ partprobe
 
 echo ">> Writing image and partition table"
 dd if=/dev/zero of="${output_image}" bs=1024000 count="${size}" || exit 1
+# make it gpt
+echo "label: gpt" | sfdisk "${output_image}"
 if [ "$model" == "rpi64" ]; then 
     sgdisk -n 1:8192:+96M -c 1:EFI -t 1:0c00 ${output_image}
 else
@@ -383,7 +385,7 @@ export device="/dev/mapper/${device}"
 
 partprobe
 
-kpartx -va $DRIVE
+kpartx -vag $DRIVE
 
 echo ">> Populating partitions"
 efi=${device}p1


### PR DESCRIPTION
The ones we create have an mbr format by default

```
Disk kairos-opensuse-leap-arm-rpi-v2.3.0-k3sv1.26.6+k3s1.img: 14,5 GiB, 15564800000 bytes, 30400000 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x00000000
```