### PR TITLE
Revert "Use GPT for raw images"

### DIFF
--- a/tools-image/build-arm-image.sh
+++ b/tools-image/build-arm-image.sh
@@ -358,8 +358,7 @@ sgdisk -n 3:0:+$(( ${recovery_size} + ${oem_size} ))M -c 3:lvm -t 3:8e00 ${outpu
 fi
 sgdisk -n 4:0:+64M -c 4:persistent -t 4:8300 ${output_image}
 
-# Make the disk GPT
-sgdisk -g ${output_image}
+sgdisk -m 1:2:3:4 ${output_image}
 
 # Prepare the image and copy over the files
 
@@ -468,7 +467,7 @@ sync
 sleep 5
 sync
 
-kpartx -dvg $DRIVE || true
+kpartx -dv $DRIVE || true
 
 umount $DRIVE || true
 

--- a/tools-image/build-arm-image.sh
+++ b/tools-image/build-arm-image.sh
@@ -360,6 +360,10 @@ sgdisk -n 4:0:+64M -c 4:persistent -t 4:8300 ${output_image}
 
 sgdisk -m 1:2:3:4 ${output_image}
 
+if [ "$model" == "rpi64" ]; then 
+    sfdisk --part-type ${output_image} 1 c
+fi
+
 # Prepare the image and copy over the files
 
 export DRIVE=$(losetup -f "${output_image}" --show)

--- a/tools-image/build-arm-image.sh
+++ b/tools-image/build-arm-image.sh
@@ -345,8 +345,6 @@ partprobe
 
 echo ">> Writing image and partition table"
 dd if=/dev/zero of="${output_image}" bs=1024000 count="${size}" || exit 1
-# make it gpt
-echo "label: gpt" | sfdisk "${output_image}"
 if [ "$model" == "rpi64" ]; then 
     sgdisk -n 1:8192:+96M -c 1:EFI -t 1:0c00 ${output_image}
 else
@@ -382,7 +380,7 @@ export device="/dev/mapper/${device}"
 
 partprobe
 
-kpartx -vag $DRIVE
+kpartx -va $DRIVE
 
 echo ">> Populating partitions"
 efi=${device}p1


### PR DESCRIPTION
This reverts gpt commits

rpi3 only supports mbr
rpi4 supports gpt

expansion of the last partition can only be done on a gpt disk
Hence we cannot blindly transform the image into gpt while supporting rpi3.

So this means, no support for last partition expansion under rpi until we drop rpi3 or we have 2 different paths for rpi3 and rpi4