### PR TITLE
Restore cross-arch build of arm images

### DIFF
--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -20,14 +20,19 @@ RUN go build \
     -o /usr/bin/enki
 
 FROM opensuse/leap:$LEAP_VERSION as default
-COPY --from=luet /usr/bin/luet /usr/bin/luet
-ENV LUET_NOLOCK=true
-ENV TMPDIR=/tmp
-COPY luet.yaml /etc/luet/luet.yaml
-
 RUN zypper ref && zypper dup -y
 ## ISO+ Arm image + Netboot + cloud images Build depedencies
 RUN zypper ref && zypper in -y bc qemu-tools jq cdrtools docker git curl gptfdisk kpartx sudo xfsprogs parted util-linux-systemd e2fsprogs curl util-linux udev rsync grub2 dosfstools grub2-x86_64-efi squashfs mtools xorriso lvm2 zstd
+COPY --from=luet /usr/bin/luet /usr/bin/luet
+ENV LUET_NOLOCK=true
+ENV TMPDIR=/tmp
+ARG BUILDARCH
+# copy both arches
+COPY luet-arm64.yaml /tmp/luet-arm64.yaml
+COPY luet-amd64.yaml /tmp/luet-amd64.yaml
+# Set the default luet config to the current build arch
+RUN mkdir -p /etc/luet/
+RUN cp /tmp/luet-${BUILDARCH}.yaml /etc/luet/luet.yaml
 
 ## Live CD artifacts
 RUN luet install -y livecd/grub2 --system-target /grub2
@@ -39,10 +44,22 @@ RUN luet install -y firmware/u-boot-rpi64 firmware/raspberrypi-firmware firmware
 ## PineBook64 Pro
 RUN luet install -y arm-vendor-blob/u-boot-rockchip --system-target /pinebookpro/u-boot
 
- ## RAW images
+## Odroid fw
+RUN luet install -y firmware/odroid-c2 --system-target /firmware/odroid-c2
+
+## RAW images for current arch
 RUN luet install -y static/grub-efi --system-target /raw/grub
 RUN luet install -y static/grub-config --system-target /raw/grubconfig
 RUN luet install -y static/grub-artifacts --system-target /raw/grubartifacts
+
+## RAW images for arm64
+# Luet will install this artifacts from the current arch repo, so in x86 it will
+# get them from the x86 repo and we want it to do it from the arm64 repo, even on x86
+# so we use the arm64 luet config and use that to install those on x86
+# This is being used by the prepare_arm_images.sh and build-arch-image.sh scripts
+RUN luet install --config /tmp/luet-arm64.yaml -y static/grub-efi --system-target /arm/raw/grub
+RUN luet install --config /tmp/luet-arm64.yaml -y static/grub-config --system-target /arm/raw/grubconfig
+RUN luet install --config /tmp/luet-arm64.yaml -y static/grub-artifacts --system-target /arm/raw/grubartifacts
 
 # remove luet tmp files. Side effect of setting the system-target is that it treats it as a root fs
 # so temporal files are stored in each dir

--- a/tools-image/arm/boards/odroid_c2.sh
+++ b/tools-image/arm/boards/odroid_c2.sh
@@ -7,15 +7,7 @@ if [ -z "$image" ]; then
     exit 1
 fi
 
-if [ ! -e "$WORKDIR/luet.yaml" ]; then
-    ls -liah $WORKDIR
-    echo "No valid config file"
-    cat "$WORKDIR/luet.yaml"
-    exit 1
-fi
-
-sudo luet install --config $WORKDIR/luet.yaml -y --system-target $WORKDIR firmware/odroid-c2
 # conv=notrunc ?
-dd if=$WORKDIR/bl1.bin.hardkernel of=$image conv=fsync bs=1 count=442
-dd if=$WORKDIR/bl1.bin.hardkernel of=$image conv=fsync bs=512 skip=1 seek=1
-dd if=$WORKDIR/u-boot.odroidc2 of=$image conv=fsync bs=512 seek=97
+dd if=/firmware/odroid-c2/bl1.bin.hardkernel of=$image conv=fsync bs=1 count=442
+dd if=/firmware/odroid-c2/bl1.bin.hardkernel of=$image conv=fsync bs=512 skip=1 seek=1
+dd if=/firmware/odroid-c2/u-boot.odroidc2 of=$image conv=fsync bs=512 seek=97

--- a/tools-image/build-arm-image.sh
+++ b/tools-image/build-arm-image.sh
@@ -321,9 +321,9 @@ cp -rfv ${STATEDIR}/cOS/active.img ${RECOVERY}/cOS/recovery.img
 tune2fs -L ${SYSTEM_LABEL} ${RECOVERY}/cOS/recovery.img
 
 # Install real grub config to recovery
-cp -rfv /raw/grubconfig/* $RECOVERY
+cp -rfv /arm/raw/grubconfig/* $RECOVERY
 mkdir -p $RECOVERY/grub2/fonts
-cp -rfv /raw/grubartifacts/* $RECOVERY/grub2
+cp -rfv /arm/raw/grubartifacts/* $RECOVERY/grub2
 mv $RECOVERY/grub2/*pf2 $RECOVERY/grub2/fonts
 
 sync

--- a/tools-image/luet-amd64.yaml
+++ b/tools-image/luet-amd64.yaml
@@ -1,0 +1,15 @@
+general:
+  debug: false
+  spinner_charset: 9
+logging:
+  enable_emoji: false
+repositories:
+  - name: "kairos"
+    description: "kairos repository"
+    type: "docker"
+    cached: true
+    enable: true
+    priority: 2
+    urls:
+      - "quay.io/kairos/packages"
+    reference: 20230718103103-repository.yaml

--- a/tools-image/luet-arm64.yaml
+++ b/tools-image/luet-arm64.yaml
@@ -4,20 +4,11 @@ general:
 logging:
   enable_emoji: false
 repositories:
-  - name: "kairos"
-    description: "kairos repository"
-    type: "docker"
-    arch: amd64
-    cached: true
-    priority: 2
-    urls:
-      - "quay.io/kairos/packages"
-    reference: 20230718103103-repository.yaml
   - name: "kairos-arm64"
     description: "kairos repository arm64"
     type: "docker"
-    arch: arm64
     cached: true
+    enable: true
     priority: 2
     urls:
       - "quay.io/kairos/packages-arm64"

--- a/tools-image/prepare_arm_images.sh
+++ b/tools-image/prepare_arm_images.sh
@@ -93,9 +93,9 @@ cp -rfv ${STATEDIR}/cOS/active.img ${RECOVERY}/cOS/recovery.img
 tune2fs -L ${SYSTEM_LABEL} ${RECOVERY}/cOS/recovery.img
 
 # Install real grub config to recovery
-cp -rfv /raw/grubconfig/* $RECOVERY
+cp -rfv /arm/raw/grubconfig/* $RECOVERY
 mkdir -p $RECOVERY/grub2/fonts
-cp -rfv /raw/grubartifacts/* $RECOVERY/grub2
+cp -rfv /arm/raw/grubartifacts/* $RECOVERY/grub2
 mv $RECOVERY/grub2/*pf2 $RECOVERY/grub2/fonts
 
 dd if=/dev/zero of=recovery_partition.img bs=1M count=$recovery_size


### PR DESCRIPTION
By playing with the buildarch and having separated luet repo files we can install the proper artifacts for each arch AND also teh arm64 artifacts for arm images under x86