### PR TITLE
Pass targetarch instead of buildarch for copying luet config

### DIFF
--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -26,13 +26,13 @@ RUN zypper ref && zypper in -y bc qemu-tools jq cdrtools docker git curl gptfdis
 COPY --from=luet /usr/bin/luet /usr/bin/luet
 ENV LUET_NOLOCK=true
 ENV TMPDIR=/tmp
-ARG BUILDARCH
+ARG TARGETARCH
 # copy both arches
 COPY luet-arm64.yaml /tmp/luet-arm64.yaml
 COPY luet-amd64.yaml /tmp/luet-amd64.yaml
 # Set the default luet config to the current build arch
 RUN mkdir -p /etc/luet/
-RUN cp /tmp/luet-${BUILDARCH}.yaml /etc/luet/luet.yaml
+RUN cp /tmp/luet-${TARGETARCH}.yaml /etc/luet/luet.yaml
 
 ## Live CD artifacts
 RUN luet install -y livecd/grub2 --system-target /grub2


### PR DESCRIPTION
relates to https://github.com/kairos-io/kairos/issues/1690
