### PR TITLE
Bump repos to get newer livecd/grub packages

### DIFF
--- a/tools-image/luet-amd64.yaml
+++ b/tools-image/luet-amd64.yaml
@@ -12,4 +12,4 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20230816121351-repository.yaml
+    reference: 20230816140633-repository.yaml

--- a/tools-image/luet-amd64.yaml
+++ b/tools-image/luet-amd64.yaml
@@ -12,4 +12,4 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20230807092210-repository.yaml
+    reference: 20230816121351-repository.yaml

--- a/tools-image/luet-arm64.yaml
+++ b/tools-image/luet-arm64.yaml
@@ -12,4 +12,4 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20230807095622-repository.yaml
+    reference: 20230816123534-repository.yaml

--- a/tools-image/luet-arm64.yaml
+++ b/tools-image/luet-arm64.yaml
@@ -12,4 +12,4 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20230816123534-repository.yaml
+    reference: 20230816141243-repository.yaml


### PR DESCRIPTION
New versions restore secureboot from cd and bundle the default grub.cfg
for livecd for both bios and efi

Signed-off-by: Itxaka <itxaka@kairos.io>