### PR TITLE
Bundle the ipxe template in the osbuilder

### DIFF
--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -96,6 +96,7 @@ COPY ./config.yaml /config/manifest.yaml
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./add-cloud-init.sh /add-cloud-init.sh
 COPY ./os-release.tmpl /os-release.tmpl
+COPY ./ipxe.tmpl /ipxe.tmpl
 COPY ./update-os-release.sh /update-os-release.sh
 
 # ARM helpers

--- a/tools-image/ipxe.tmpl
+++ b/tools-image/ipxe.tmpl
@@ -1,0 +1,7 @@
+#!ipxe
+
+set dns 8.8.8.8
+ifconf
+kernel ${RELEASE_URL}/${VERSION}/${ISO_NAME}-kernel root=live:${RELEASE_URL}/${VERSION}/${ISO_NAME}.squashfs initrd=${ISO_NAME}-initrd rd.neednet=1 ip=dhcp rd.cos.disable netboot nodepair.enable config_url=${config} console=tty1 console=ttyS0 rd.live.overlay.overlayfs ${cmdline}
+initrd ${RELEASE_URL}/${VERSION}/${ISO_NAME}-initrd
+boot


### PR DESCRIPTION
So it can be used when building ipxe stuff instead of being walled in the kairos repo