### PR TITLE
example: add script to generate bios mbr raw disks

### DIFF
--- a/tools-image/bios-raw-image.sh
+++ b/tools-image/bios-raw-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Generates raw bootable images with qemu
+set -ex
+CLOUD_INIT=${1:-cloud_init.yaml}
+QEMU=${QEMU:-qemu-system-x86_64}
+ISO=${2:-iso.iso}
+
+mkdir -p build
+pushd build
+touch meta-data
+cp -rfv $CLOUD_INIT user-data
+
+mkisofs -output ci.iso -volid cidata -joliet -rock user-data meta-data
+truncate -s "+$((20000*1024*1024))" disk.raw
+
+${QEMU} -m 8096 -smp cores=2 \
+        -nographic -cpu host \
+        -serial mon:stdio \
+        -rtc base=utc,clock=rt \
+        -chardev socket,path=qga.sock,server,nowait,id=qga0 \
+        -device virtio-serial \
+        -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 \
+        -drive if=virtio,media=disk,file=disk.raw \
+        -drive format=raw,media=cdrom,readonly=on,file=$ISO \
+        -drive format=raw,media=cdrom,readonly=on,file=ci.iso \
+        -boot d \
+        -enable-kvm


### PR DESCRIPTION
this needs refactoring and add to auroraboot, but it needs a cloud config of this format (the install block is relevant here, where it automatically power off after install):
```yaml
#cloud-config

hostname: kairos-{{ trunc 4 .MachineID }}

# Automated install block
install:
  # Device for automated installs
  device: "auto"
  # Reboot after installation
  reboot: false
  # Power off after installation
  poweroff: true
  # Set to true to enable automated installations
  auto: true

## Login
users:
- name: "kairos"
  lock_passwd: true
  ssh_authorized_keys:
  - github:mudler

stages:
  boot:
  - name: "Repart image"
    layout:
      device:
        label: COS_PERSISTENT
      expand_partition:
        size: 0 # all space
    commands:
      # grow filesystem if not used 100%
      - |
         [[ "$(echo "$(df -h | grep COS_PERSISTENT)" | awk '{print $5}' | tr -d '%')" -ne 100 ]] && resize2fs /dev/disk/by-label/COS_PERSISTENT
```