### PR TITLE
Drop usage of system/grub2-efi package as a source

### DIFF
--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -1,7 +1,7 @@
 # https://quay.io/repository/kairos/packages?tab=tags&tag=latest
 ARG LEAP_VERSION=15.5
 ARG LUET_VERSION=0.35.0
-ARG ENKI_VERSION=v0.0.3
+ARG ENKI_VERSION=v0.0.4
 
 FROM quay.io/luet/base:$LUET_VERSION AS luet
 FROM quay.io/kairos/enki:${ENKI_VERSION} as enki

--- a/tools-image/config.yaml
+++ b/tools-image/config.yaml
@@ -1,6 +1,3 @@
 iso:
-  uefi:
-  - dir:/efi
   image:
-  - dir:/efi
   - dir:/grub2


### PR DESCRIPTION
Now rootfs needs to provide their artifacts from packages so the dir is no longer used, so the config needs to change

The package is still there as alpine will need it as a last resort but it wont support secureboot

Needs: https://github.com/kairos-io/enki/pull/17 and a new enki version released