### PR TITLE
Use fedora 40 for os tools container

### DIFF
--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -1,5 +1,5 @@
 # https://quay.io/repository/kairos/packages?tab=tags&tag=latest
-ARG FEDORA_VERSION=39
+ARG FEDORA_VERSION=40
 ARG LUET_VERSION=0.35.0
 ARG ENKI_VERSION=v0.0.16
 

--- a/tools-image/build-arm-image.sh
+++ b/tools-image/build-arm-image.sh
@@ -364,14 +364,11 @@ if [ "$model" == "rpi3" ]; then
     sgdisk -m 1:2:3:4 ${output_image}
     sfdisk --part-type ${output_image} 1 c
 elif [ "$model" == "rpi4" ]; then
-    echo "label: gpt" | sfdisk "${output_image}"
     sgdisk -n 1:8192:+96M -c 1:EFI -t 1:0c00 ${output_image}
     sgdisk -n 2:0:+${state_size}M -c 2:state -t 2:8300 ${output_image}
     sgdisk -n 3:0:+${recovery_size}M -c 3:recovery -t 3:8300 ${output_image}
     sgdisk -n 4:0:+${oem_size}M -c 4:oem -t 4:8300 ${output_image}
     sgdisk -n 5:0:+64M -c 5:persistent -t 5:8300 ${output_image}
-    sgdisk -g ${output_image}
-    sgdisk -m 1:2:3:4:5 ${output_image}
 else
     sgdisk -n 1:8192:+16M -c 1:EFI -t 1:0700 ${output_image}
     sgdisk -n 2:0:+${state_size}M -c 2:state -t 2:8300 ${output_image}


### PR DESCRIPTION
Fixes an issue with sgdisk creating the disk images properly Alos removes some uneeded options from the rpi4 disk cration:
 - `-g` option mean to transform mbr to gptt, but the disk was already gpt
 - `-m` option tried to make the disk mbr from gpt... not sure why that was there
 - creating the disk with gpt. There is no need as sgdisk will default to create a gpt disk