### PR TITLE
fix(entrypoint.sh): quote when passing-by arguments

### DIFF
--- a/tools-image/entrypoint.sh
+++ b/tools-image/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-enki --config-dir /config $@
+enki --config-dir /config "$@"


### PR DESCRIPTION
This fixes using the wrapper when calling it with quotes, e.g.:

```
/entrypoint.sh build-uki dir:/build/image --cmdline "foo bar baz" --overlay /overlay -t iso -d /iso -k /keys
```