### PR TITLE
Update Enki to v0.0.22

### DIFF
--- a/tools-image/Dockerfile
+++ b/tools-image/Dockerfile
@@ -1,7 +1,7 @@
 # https://quay.io/repository/kairos/packages?tab=tags&tag=latest
 ARG LEAP_VERSION=15.5
 ARG LUET_VERSION=0.35.0
-ARG ENKI_VERSION=v0.0.21
+ARG ENKI_VERSION=v0.0.22
 
 FROM quay.io/luet/base:$LUET_VERSION AS luet
 FROM quay.io/kairos/enki:${ENKI_VERSION} as enki


### PR DESCRIPTION
Relates to the UKI boot labeling